### PR TITLE
Create indexing.js

### DIFF
--- a/indexing.js
+++ b/indexing.js
@@ -1,0 +1,60 @@
+//SingleFieldIndex
+db.student.createIndex({"class_id":551},
+{
+"createdCollectionAutomatically" :
+false,
+"numIndexesBefore": 1,
+"numIndexsAfter": 2,
+"ok" : 1
+})
+
+< class_id_551
+> db.student.getIndexes()
+
+
+//CompoundIndex
+  db.student.createIndex({student_id: 777777, student_id: 223344},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< student_id_223344
+> db.student.getIndexes()
+
+
+//MultikeyIndex
+db.student.createIndex({student:1},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< student_1
+> db.student.getIndexes()
+
+
+//GeoSpatial
+db.student.createIndex({"score":"2dsphere"},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})
+
+< score_2dsphere
+> db.student.getIndexes()
+
+//Dropindex
+db.student.dropIndex({key: {student_id:551}},
+{
+			"createdCollectionAutomatically": false,
+			"numIdexesBefore":1,
+			"numIndexesAfter":2,
+			"ok":1
+})


### PR DESCRIPTION
Indexing: 
Indexing in MongoDB is a crucial feature for optimizing query performance and improving the efficiency of data retrieval operations. 
steps to create indexes and use them are given below:

Single-field Indexes: These indexes are created on a single field in a document. They are useful for efficiently querying documents based on the value of that field.

<img width="1512" alt="ss 1" src="https://github.com/PeterPrince3110/mongodbcrud/assets/157638205/d7ff50a8-6a42-4de6-a037-a15203b13d78">

Compound Indexes: Compound indexes are created on multiple fields in a document. They enable efficient querying and sorting based on combinations of those fields.

<img width="358" alt="ss2" src="https://github.com/PeterPrince3110/mongodbcrud/assets/157638205/805d4558-0d3a-469c-a6a1-bf69edcd952c">

Multikey Indexes: MongoDB allows indexing arrays, and multikey indexes are used to index arrays within documents. This enables efficient querying on fields that contain arrays of values.

<img width="777" alt="ss3" src="https://github.com/PeterPrince3110/mongodbcrud/assets/157638205/cd83070f-509a-4f3f-a09f-a5ceeabd61ab">


Geospatial Indexes: Geospatial indexes are used for querying documents based on their geographic location. They enable efficient retrieval of documents that fall within a specified 

<img width="361" alt="ss4" src="https://github.com/PeterPrince3110/mongodbcrud/assets/157638205/1e81a57e-f412-4c12-ae6b-66eb5c6b6bb6">


Dropping an index: Dropping an index in MongoDB means removing the index structure that was previously created on a collection's fields. 

<img width="332" alt="ss5" src="https://github.com/PeterPrince3110/mongodbcrud/assets/157638205/e0ef737e-459e-4f12-9aec-6bf9a641c66e">


